### PR TITLE
Switched exp date and create date field names on payment type

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -20,7 +20,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             lookup_field='id'
         )
         fields = ('id', 'url', 'merchant_name', 'account_number',
-                  'expiration_date', 'create_date')
+                'expiration_date', 'create_date')
 
 
 class Payments(ViewSet):
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- Switched exp date and create date field names on payment type to resolve date error

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

POST `/paymenttypes` Creates a new payment type

```json
{
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

**Response**

HTTP/1.1 201 OK

```json
{
    "id": 4,
    "url": "http://localhost:8000/paymenttypes/4",
    "merchant_name": "Amex",
    "account_number": "000000000000",
    "expiration_date": "2023-12-12",
    "create_date": "2020-12-12"
}
```

## Testing

Description of how to test code...

- [x] Use Postman to POST above JSON data
- [x] Confirm exp and create dates are in correct fields


## Related Issues

- Fixes #19 